### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,6 @@ flask_sqlalchemy==2.3.2
 starlingbank==3.2
 python-dateutil==2.7.5
 click==7.0
-psycopg2==2.8.4
 
 gunicorn==19.9.0
+psycopg2==2.8.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,6 @@ flask_sqlalchemy==2.3.2
 starlingbank==3.2
 python-dateutil==2.7.5
 click==7.0
+psycopg2==2.8.4
 
 gunicorn==19.9.0


### PR DESCRIPTION
Updated requirements to include `psycopg2`. Without this, opening the app on Heroku resulted in `ModuleNotFoundError: No module named 'psycopg2'`.